### PR TITLE
Don't modify undo stack when calling `getChangesSinceCheckpoint`

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -309,7 +309,7 @@ class Document {
   groupChangesSinceCheckpoint (checkpointId, options) {
     if (this.isBarrierPresentBeforeCheckpoint(checkpointId)) return false
 
-    const result = this.collectOperationsSinceCheckpoint(checkpointId, options && options.deleteCheckpoint)
+    const result = this.collectOperationsSinceCheckpoint(checkpointId, true, options && options.deleteCheckpoint)
     if (result) {
       const {operations, markersSnapshot}  = result
       if (operations.length > 0) {
@@ -331,7 +331,7 @@ class Document {
   revertToCheckpoint (checkpointId, options) {
     if (this.isBarrierPresentBeforeCheckpoint(checkpointId)) return false
 
-    const collectResult = this.collectOperationsSinceCheckpoint(checkpointId, options && options.deleteCheckpoint)
+    const collectResult = this.collectOperationsSinceCheckpoint(checkpointId, true, options && options.deleteCheckpoint)
     if (collectResult) {
       const {operations, textUpdates} = this.undoOrRedoOperations(collectResult.operations)
       const markers = this.markersFromSnapshot(collectResult.markersSnapshot)
@@ -342,7 +342,7 @@ class Document {
   }
 
   getChangesSinceCheckpoint (checkpointId) {
-    const result = this.collectOperationsSinceCheckpoint(checkpointId)
+    const result = this.collectOperationsSinceCheckpoint(checkpointId, false, false)
     if (result) {
       return this.textUpdatesForOperations(result.operations)
     } else {
@@ -350,7 +350,7 @@ class Document {
     }
   }
 
-  collectOperationsSinceCheckpoint (checkpointId, deleteCheckpoint) {
+  collectOperationsSinceCheckpoint (checkpointId, deleteOperations, deleteCheckpoint) {
     let checkpointIndex = -1
     const operations = []
     for (let i = this.undoStack.length - 1; i >= 0; i--) {
@@ -371,8 +371,10 @@ class Document {
       return null
     } else {
       const {markersSnapshot} = this.undoStack[checkpointIndex]
-      if (!deleteCheckpoint) checkpointIndex++
-      this.undoStack.splice(checkpointIndex)
+      if (deleteOperations) {
+        if (!deleteCheckpoint) checkpointIndex++
+        this.undoStack.splice(checkpointIndex)
+      }
       return {operations, markersSnapshot}
     }
   }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -782,6 +782,9 @@ suite('Document', () => {
         replicaA.testLocalDocument.setTextInRange(change.newStart, change.newEnd, change.oldText)
       }
       assert.equal(replicaA.testLocalDocument.text, 'b1 a1 ')
+
+      // Ensure we don't modify the undo stack when getting changes since checkpoint (regression).
+      assert.deepEqual(replicaA.getChangesSinceCheckpoint(checkpoint), changesSinceCheckpoint)
     })
 
     test('undoing and redoing an operation that occurred adjacent to a checkpoint', () => {


### PR DESCRIPTION
Getting changes since a checkpoint should be a non-destructive action and should not modify the undo stack.

/cc: @nathansobo @jasonrudolph 