### PR TITLE
Documentation for public Document methods

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -109,7 +109,7 @@ class Document {
   /*
   Public: Modify the Document's text.
 
-  The modification can be a deletion, insertion, or both.
+  The modification can be a deletion, insertion, or both (an overwrite).
   If `end` is after `start` in the document, the operation is a deletion.
   If `text` is passed, the operation is an insertion.
 
@@ -176,6 +176,7 @@ class Document {
   * `layerUpdatesById` {Object} of shape:
     * {Number} Marker layer ID
       * {Numer} Marker ID
+        * {Marker}
 
   Returns an {Array} of the marker update operation.
   */
@@ -236,7 +237,9 @@ class Document {
   }
 
   /*
-  Public: Undoes one or more operations.
+  Public: Undoes the latest Transaction on the undo stack.
+
+  If there's a barrier before the latest Transaction, nothing happens.
 
   Returns null or {Object} of shape:
     * `markers` {Object} of shape:
@@ -279,7 +282,7 @@ class Document {
   }
 
   /*
-  Public: Redoes one or more operations.
+  Public: Redoes the latest Transaction on the redo stack.
 
   Returns null or {Object} of shape:
     * `markers` {Object} of shape:
@@ -332,9 +335,13 @@ class Document {
   }
 
   /*
-  Public: Sets the interval for grouping transactions.
+  Public: Sets the interval for grouping Transactions.
+
+  If the updates grouping interval would contain the two latest transactions,
+  they are grouped.
 
   * `groupingInterval` {Number} of milliseconds
+
   */
   applyGroupingInterval (groupingInterval) {
     const topEntry = this.undoStack[this.undoStack.length - 1]
@@ -418,6 +425,9 @@ class Document {
 
   /*
   Public: Reverts the document to a checkpoint in the undo stack.
+
+  If a barrier exists in the undo stack before the checkpoint matching
+  `checkpointId`, the reversion fails.
 
   * `checkpointId` {Number}
   * `options` {Object} of shape:
@@ -791,7 +801,6 @@ class Document {
 
   Returns {Object} of shape:
   * `markerUpdates` {Object} of shape:
-  // TODO confirm site ID here
     * {Number} Site ID
       * {Number} Marker layer ID
         * {Number} Marker ID

--- a/lib/document.js
+++ b/lib/document.js
@@ -79,6 +79,11 @@ class Document {
     return replica
   }
 
+  /*
+  Public: Get operations integrated in the document.
+
+  Returns an {Array} of operations and marker updates.
+  */
   getOperations () {
     const markerOperations = []
     this.markerLayersBySiteId.forEach((layersById, siteId) => {
@@ -101,6 +106,20 @@ class Document {
     return this.operations.concat(markerOperations)
   }
 
+  /*
+  Public: Modify the Document's text.
+
+  The modification can be a deletion, insertion, or both.
+  If `end` is after `start` in the document, the operation is a deletion.
+  If `text` is passed, the operation is an insertion.
+
+  * `start` {Point}
+  * `end` {Point}
+  * `text` {String}
+  * `options` unused TODO
+
+  Returns an {Array} containing the integrated operation.
+  */
   setTextInRange (start, end, text, options) {
     const spliceId = {site: this.siteId, seq: this.nextSequenceNumber}
     const operation = {type: 'splice', spliceId}
@@ -120,6 +139,15 @@ class Document {
     return [operation]
   }
 
+  /*
+  Public: Get markers present in the Document.
+
+  Returns an {Object} of shape:
+    * {Number} Site ID
+      * {Number} Marker layer ID
+        * {Number} Marker ID
+          * {Marker}
+  */
   getMarkers () {
     const result = {}
     this.markerLayersBySiteId.forEach((layersById, siteId) => {
@@ -139,6 +167,18 @@ class Document {
     return result
   }
 
+  /*
+  Public: Updates markers in the Document.
+
+  If a Marker exists with the specified ID, its value is updated.
+  If no Marker exists with the specified ID, one is created.
+
+  * `layerUpdatesById` {Object} of shape:
+    * {Number} Marker layer ID
+      * {Numer} Marker ID
+
+  Returns an {Array} of the marker update operation.
+  */
   updateMarkers (layerUpdatesById) {
     const operation = {
       type: 'markers-update',
@@ -195,6 +235,23 @@ class Document {
     return [operation]
   }
 
+  /*
+  Public: Undoes one or more operations.
+
+  Returns null or {Object} of shape:
+    * `markers` {Object} of shape:
+      * {Number} Marker layer ID
+        * {Number} Marker ID
+          * {Marker}
+    * `textUpdates` {Array} of {Object}s of shape:
+      * `oldStart` {Point}
+      * `oldEnd` {Point}
+      * `oldText` {String}
+      * `newStart` {Point}
+      * `newEnd` {Point}
+      * `newText` {String}
+    * `operations` {Array} of operations
+  */
   undo () {
     let spliceIndex = null
     let operationsToUndo = []
@@ -221,6 +278,23 @@ class Document {
     }
   }
 
+  /*
+  Public: Redoes one or more operations.
+
+  Returns null or {Object} of shape:
+    * `markers` {Object} of shape:
+      * {Number} Marker layer ID
+        * {Number} Marker ID
+          * {Marker}
+    * `textUpdates` {Array} of {Object}s of shape:
+      * `oldStart: {Point}
+      * `oldEnd` {Point}
+      * `oldText` {String}
+      * `newStart` {Point}
+      * `newEnd` {Point}
+      * `newText` {String}
+    * `operations` {Array} of operations
+  */
   redo () {
     let spliceIndex = null
     let operationsToRedo = []
@@ -257,6 +331,11 @@ class Document {
     this.redoStack.length = 0
   }
 
+  /*
+  Public: Sets the interval for grouping transactions.
+
+  * `groupingInterval` {Number} of milliseconds
+  */
   applyGroupingInterval (groupingInterval) {
     const topEntry = this.undoStack[this.undoStack.length - 1]
     const previousEntry = this.undoStack[this.undoStack.length - 2]
@@ -284,6 +363,15 @@ class Document {
     return Date.now()
   }
 
+  /*
+  Public: Creates a checkpoint in the undo stack.
+
+  * `options` {Object} of shape:
+    * `isBarrier` {Bool}
+    * `markers` {Array} of {Marker}s
+
+  Returns {Number}
+  */
   createCheckpoint (options) {
     const checkpoint = new Checkpoint(
       this.nextCheckpointId++,
@@ -328,6 +416,27 @@ class Document {
     }
   }
 
+  /*
+  Public: Reverts the document to a checkpoint in the undo stack.
+
+  * `checkpointId` {Number}
+  * `options` {Object} of shape:
+    * `deleteCheckpoint` {Bool}
+
+  Returns false if the revert couldn't be completed, else returns {Object} of shape:
+      * `markers` {Object} of shape:
+        * {Number} Marker layer ID
+          * {Number} Marker ID
+            * {Marker}
+      * `textUpdates` {Array} of {Object}s of shape:
+        * `oldStart` {Point}
+        * `oldEnd` {Point}
+        * `oldText` {String}
+        * `newStart` {Point}
+        * `newEnd` {Point}
+        * `newText` {String}
+      * `operations` {Array} of operations
+  */
   revertToCheckpoint (checkpointId, options) {
     if (this.isBarrierPresentBeforeCheckpoint(checkpointId)) return false
 
@@ -341,6 +450,19 @@ class Document {
     }
   }
 
+  /*
+  Public: Gets changes performed since a checkpoint.
+
+  * `checkpointId` {Number}
+
+  Returns false or {Array} of {Object}s of shape:
+    * `oldStart` {Point}
+    * `oldEnd` {Point}
+    * `oldText` {String}
+    * `newStart` {Point}
+    * `newEnd` {Point}
+    * `newText` {String}
+  */
   getChangesSinceCheckpoint (checkpointId) {
     const result = this.collectOperationsSinceCheckpoint(checkpointId, false, false)
     if (result) {
@@ -379,6 +501,11 @@ class Document {
     }
   }
 
+  /*
+  Public: Groups the last changes on the undo stack.
+
+  Returns true if a grouping was made, else false.
+  */
   groupLastChanges () {
     let lastTransaction
 
@@ -406,6 +533,63 @@ class Document {
     return false
   }
 
+  /*
+  Public: Get history entries from the undo and redo stacks.
+
+  * `maxEntries` {Number} of history entries to return
+
+  Returns {Object} of shape:
+    * `nextCheckpointId` {Number}
+    * `undoStack` {Array} of {Object}s, either of shape:
+      * `type` {String} 'transaction'
+      * `changes` {Array} of {Object}s of shape:
+          * `oldStart` {Point}
+          * `oldEnd` {Point}
+          * `oldText` {String}
+          * `newStart` {Point}
+          * `newEnd` {Point}
+          * `newText` {String}
+      * `markersBefore` {Object} of shape:
+        * {Number} Marker layer ID
+          * {Number} Marker ID
+            * {Marker}
+      * `markersAfter` {Object} of shape:
+        * {Number} Marker layer ID
+          * {Number} Marker ID
+            * {Marker}
+      or of shape
+      * `type` {String} 'checkpoint'
+      * `id` {Number}
+      * `markers` {Object} of shape:
+        * {Number} Marker layer ID
+          * {Number} Marker ID
+            * {Marker}
+    * `redoStack` {Array} of {Object}s, either of shape:
+      * `type` {String} 'transaction'
+      * `changes` {Array} of {Object}s of shape:
+          * `oldStart` {Point}
+          * `oldEnd` {Point}
+          * `oldText` {String}
+          * `newStart` {Point}
+          * `newEnd` {Point}
+          * `newText` {String}
+      * `markersBefore` {Object} of shape:
+        * {Number} Marker layer ID
+          * {Number} Marker ID
+            * {Marker}
+      * `markersAfter` {Object} of shape:
+        * {Number} Marker layer ID
+          * {Number} Marker ID
+            * {Marker}
+      or of shape
+      * `type` {String} 'checkpoint'
+      * `id` {Number}
+      * `markers` {Object} of shape:
+        * {Number} Marker layer ID
+          * {Number} Marker ID
+            * {Marker}
+
+  */
   getHistory (maxEntries) {
     const originalUndoCounts = new Map(this.undoCountsBySpliceId)
 
@@ -600,6 +784,26 @@ class Document {
     }
   }
 
+  /*
+  Public: Integrate operations locally.
+
+  * `operations` {Array} of operations.
+
+  Returns {Object} of shape:
+  * `markerUpdates` {Object} of shape:
+  // TODO confirm site ID here
+    * {Number} Site ID
+      * {Number} Marker layer ID
+        * {Number} Marker ID
+          * {Marker}
+  * `textUpdates` {Array} of {Object}s of shape:
+    * `oldStart` {Point}
+    * `oldEnd` {Point}
+    * `oldText` {String}
+    * `newStart` {Point}
+    * `newEnd` {Point}
+    * `newText` {String}
+  */
   integrateOperations (operations) {
     const integratedOperations = []
     let oldUndoCounts
@@ -1093,6 +1297,11 @@ class Document {
     }
   }
 
+  /*
+  Public: Get the text of the Document.
+
+  Returns {String}
+  */
   getText () {
     let text = ''
     const segments = this.documentTree.getSegments()

--- a/lib/document.js
+++ b/lib/document.js
@@ -115,8 +115,8 @@ class Document {
   If `end` is after `start` in the document, the operation is a deletion.
   If `text` is passed, the operation is an insertion.
 
-  * `start` {Point}
-  * `end` {Point}
+  * `start` Point {Object}
+  * `end` Point {Object}
   * `text` {String}
   * `options` unused TODO
 
@@ -148,7 +148,7 @@ class Document {
     * {Number} Site ID
       * {Number} Marker layer ID
         * {Number} Marker ID
-          * {Marker}
+          * Marker {Object}
   */
   getMarkers () {
     const result = {}
@@ -178,7 +178,7 @@ class Document {
   * `layerUpdatesById` {Object} of shape:
     * {Number} Marker layer ID
       * {Numer} Marker ID
-        * {Marker}
+        * Marker {Object}
 
   Returns an {Array} of the marker update operation.
   */
@@ -247,13 +247,13 @@ class Document {
     * `markers` {Object} of shape:
       * {Number} Marker layer ID
         * {Number} Marker ID
-          * {Marker}
+          * Marker {Object}
     * `textUpdates` {Array} of {Object}s of shape:
-      * `oldStart` {Point}
-      * `oldEnd` {Point}
+      * `oldStart` Point {Object}
+      * `oldEnd` Point {Object}
       * `oldText` {String}
-      * `newStart` {Point}
-      * `newEnd` {Point}
+      * `newStart` Point {Object}
+      * `newEnd` Point {Object}
       * `newText` {String}
     * `operations` {Array} of operations
   */
@@ -290,13 +290,13 @@ class Document {
     * `markers` {Object} of shape:
       * {Number} Marker layer ID
         * {Number} Marker ID
-          * {Marker}
+          * Marker {Object}
     * `textUpdates` {Array} of {Object}s of shape:
-      * `oldStart: {Point}
-      * `oldEnd` {Point}
+      * `oldStart: Point {Object}
+      * `oldEnd` Point {Object}
       * `oldText` {String}
-      * `newStart` {Point}
-      * `newEnd` {Point}
+      * `newStart` Point {Object}
+      * `newEnd` Point {Object}
       * `newText` {String}
     * `operations` {Array} of operations
   */
@@ -380,7 +380,7 @@ class Document {
 
   * `options` {Object} of shape:
     * `isBarrier` {Bool}
-    * `markers` {Array} of {Marker}s
+    * `markers` {Array} of Marker {Object}s
 
   Returns {Number}
   */
@@ -452,13 +452,13 @@ class Document {
       * `markers` {Object} of shape:
         * {Number} Marker layer ID
           * {Number} Marker ID
-            * {Marker}
+            * Marker {Object}
       * `textUpdates` {Array} of {Object}s of shape:
-        * `oldStart` {Point}
-        * `oldEnd` {Point}
+        * `oldStart` Point {Object}
+        * `oldEnd` Point {Object}
         * `oldText` {String}
-        * `newStart` {Point}
-        * `newEnd` {Point}
+        * `newStart` Point {Object}
+        * `newEnd` Point {Object}
         * `newText` {String}
       * `operations` {Array} of operations
   */
@@ -481,11 +481,11 @@ class Document {
   * `checkpointId` {Number}
 
   Returns false or {Array} of {Object}s of shape:
-    * `oldStart` {Point}
-    * `oldEnd` {Point}
+    * `oldStart` Point {Object}
+    * `oldEnd` Point {Object}
     * `oldText` {String}
-    * `newStart` {Point}
-    * `newEnd` {Point}
+    * `newStart` Point {Object}
+    * `newEnd` Point {Object}
     * `newText` {String}
   */
   getChangesSinceCheckpoint (checkpointId) {
@@ -638,8 +638,8 @@ class Document {
   Private: Deletes text between `start` and `end`.
 
   * `spliceId` {Number}
-  * `start` {Point}
-  * `end` {Point}
+  * `start` Point {Object}
+  * `end` Point {Object}
 
   Returns deletion operation {Object}
   */
@@ -680,7 +680,7 @@ class Document {
   Private: Inserts `text` at `position`.
 
   * `spliceId` {Number}
-  * `position` {Point}
+  * `position` Point {Object}
   * `text` {String}
 
   Returns insertion operation {Object}
@@ -793,13 +793,13 @@ class Document {
     * {Number} Site ID
       * {Number} Marker layer ID
         * {Number} Marker ID
-          * {Marker}
+          * Marker {Object}
   * `textUpdates` {Array} of {Object}s of shape:
-    * `oldStart` {Point}
-    * `oldEnd` {Point}
+    * `oldStart` Point {Object}
+    * `oldEnd` Point {Object}
     * `oldText` {String}
-    * `newStart` {Point}
-    * `newEnd` {Point}
+    * `newStart` Point {Object}
+    * `newEnd` Point {Object}
     * `newText` {String}
   */
   integrateOperations (operations) {

--- a/lib/document.js
+++ b/lib/document.js
@@ -82,6 +82,8 @@ class Document {
   /*
   Public: Get operations integrated in the document.
 
+  Operations are both text operations and marker updates.
+
   Returns an {Array} of operations and marker updates.
   */
   getOperations () {
@@ -371,7 +373,10 @@ class Document {
   }
 
   /*
-  Public: Creates a checkpoint in the undo stack.
+  Public: Creates a Checkpoint in the undo stack.
+
+  If a Checkpoint is a barrier, Transactions chronologically before it cannot be
+  undone or grouped with Transactions before it.
 
   * `options` {Object} of shape:
     * `isBarrier` {Bool}
@@ -389,6 +394,16 @@ class Document {
     return checkpoint.id
   }
 
+  /*
+  Private: Checks if a barrier Checkpoint is present chronologically
+  before a given Checkpoint.
+
+  This is used to prevent undo operations or Transaction grouping over barriers.
+
+  * `checkpointId` {Number}
+
+  Returns {Bool}
+  */
   isBarrierPresentBeforeCheckpoint (checkpointId) {
     for (let i = this.undoStack.length - 1; i >= 0; i--) {
       const stackEntry = this.undoStack[i]
@@ -512,7 +527,7 @@ class Document {
   }
 
   /*
-  Public: Groups the last changes on the undo stack.
+  Public: Groups the last two changes on the undo stack.
 
   Returns true if a grouping was made, else false.
   */
@@ -550,55 +565,8 @@ class Document {
 
   Returns {Object} of shape:
     * `nextCheckpointId` {Number}
-    * `undoStack` {Array} of {Object}s, either of shape:
-      * `type` {String} 'transaction'
-      * `changes` {Array} of {Object}s of shape:
-          * `oldStart` {Point}
-          * `oldEnd` {Point}
-          * `oldText` {String}
-          * `newStart` {Point}
-          * `newEnd` {Point}
-          * `newText` {String}
-      * `markersBefore` {Object} of shape:
-        * {Number} Marker layer ID
-          * {Number} Marker ID
-            * {Marker}
-      * `markersAfter` {Object} of shape:
-        * {Number} Marker layer ID
-          * {Number} Marker ID
-            * {Marker}
-      or of shape
-      * `type` {String} 'checkpoint'
-      * `id` {Number}
-      * `markers` {Object} of shape:
-        * {Number} Marker layer ID
-          * {Number} Marker ID
-            * {Marker}
-    * `redoStack` {Array} of {Object}s, either of shape:
-      * `type` {String} 'transaction'
-      * `changes` {Array} of {Object}s of shape:
-          * `oldStart` {Point}
-          * `oldEnd` {Point}
-          * `oldText` {String}
-          * `newStart` {Point}
-          * `newEnd` {Point}
-          * `newText` {String}
-      * `markersBefore` {Object} of shape:
-        * {Number} Marker layer ID
-          * {Number} Marker ID
-            * {Marker}
-      * `markersAfter` {Object} of shape:
-        * {Number} Marker layer ID
-          * {Number} Marker ID
-            * {Marker}
-      or of shape
-      * `type` {String} 'checkpoint'
-      * `id` {Number}
-      * `markers` {Object} of shape:
-        * {Number} Marker layer ID
-          * {Number} Marker ID
-            * {Marker}
-
+    * `undoStack` {Array} of either Checkpoint or Transaction {Object}s
+    * `redoStack` {Array} of either Checkpoint or Transaction {Object}s
   */
   getHistory (maxEntries) {
     const originalUndoCounts = new Map(this.undoCountsBySpliceId)
@@ -666,6 +634,15 @@ class Document {
     }
   }
 
+  /*
+  Private: Delete text between `start` and `end`.
+
+  * `spliceId` {Number}
+  * `start` {Point}
+  * `end` {Point}
+
+  Returns deletion operation {Object}
+  */
   delete (spliceId, start, end) {
     const spliceIdString = spliceIdToString(spliceId)
 
@@ -699,6 +676,15 @@ class Document {
     return deletion
   }
 
+  /*
+  Private: Insert `text` at `position`.
+
+  * `spliceId` {Number}
+  * `position` {Point}
+  * `text` {String}
+
+  Returns insertion operation {Object}
+  */
   insert (spliceId, position, text) {
     const [left, right] = this.findLocalSegmentBoundary(position)
     const newSegment = {
@@ -796,6 +782,8 @@ class Document {
 
   /*
   Public: Integrate operations locally.
+
+  Operations performed at other sites and sent over the wire are
 
   * `operations` {Array} of operations.
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -80,7 +80,7 @@ class Document {
   }
 
   /*
-  Public: Get operations integrated in the document.
+  Public: Gets operations integrated in the document.
 
   Operations are both text operations and marker updates.
 
@@ -109,7 +109,7 @@ class Document {
   }
 
   /*
-  Public: Modify the Document's text.
+  Public: Modifies the Document's text.
 
   The modification can be a deletion, insertion, or both (an overwrite).
   If `end` is after `start` in the document, the operation is a deletion.
@@ -142,7 +142,7 @@ class Document {
   }
 
   /*
-  Public: Get markers present in the Document.
+  Public: Gets markers present in the Document.
 
   Returns an {Object} of shape:
     * {Number} Site ID
@@ -559,7 +559,7 @@ class Document {
   }
 
   /*
-  Public: Get history entries from the undo and redo stacks.
+  Public: Gets history entries from the undo and redo stacks.
 
   * `maxEntries` {Number} of history entries to return
 
@@ -635,7 +635,7 @@ class Document {
   }
 
   /*
-  Private: Delete text between `start` and `end`.
+  Private: Deletes text between `start` and `end`.
 
   * `spliceId` {Number}
   * `start` {Point}
@@ -677,7 +677,7 @@ class Document {
   }
 
   /*
-  Private: Insert `text` at `position`.
+  Private: Inserts `text` at `position`.
 
   * `spliceId` {Number}
   * `position` {Point}
@@ -781,9 +781,10 @@ class Document {
   }
 
   /*
-  Public: Integrate operations locally.
+  Public: Integrates operations locally.
 
-  Operations performed at other sites and sent over the wire are
+  Operations performed at other sites are serialized and sent over the wire,
+  then deserialized and integreated locally.
 
   * `operations` {Array} of operations.
 
@@ -1295,7 +1296,7 @@ class Document {
   }
 
   /*
-  Public: Get the text of the Document.
+  Public: Gets the text of the Document.
 
   Returns {String}
   */

--- a/lib/serialization.js
+++ b/lib/serialization.js
@@ -1,5 +1,12 @@
 const {Operation} = require('./teletype-crdt_pb')
 
+/*
+Public: Serializes an operation.
+
+* `op` operation {Object}, either a splice, undo, or marker update.
+
+Returns a serialize message {Object}
+*/
 function serializeOperation (op) {
   const operationMessage = new Operation()
   switch (op.type) {
@@ -118,6 +125,13 @@ function serializePoint ({row, column}) {
   return pointMessage
 }
 
+/*
+Public: Serializes an operation.
+
+* `operationMessage` operation message {Object}
+
+Returns an operation {Object}
+*/
 function deserializeOperation (operationMessage) {
   if (operationMessage.hasSplice()) {
     return deserializeSplice(operationMessage.getSplice())

--- a/lib/serialization.js
+++ b/lib/serialization.js
@@ -1,12 +1,5 @@
 const {Operation} = require('./teletype-crdt_pb')
 
-/*
-Public: Serializes an operation.
-
-* `op` operation {Object}, either a splice, undo, or marker update.
-
-Returns a serialize message {Object}
-*/
 function serializeOperation (op) {
   const operationMessage = new Operation()
   switch (op.type) {
@@ -125,13 +118,6 @@ function serializePoint ({row, column}) {
   return pointMessage
 }
 
-/*
-Public: Serializes an operation.
-
-* `operationMessage` operation message {Object}
-
-Returns an operation {Object}
-*/
 function deserializeOperation (operationMessage) {
   if (operationMessage.hasSplice()) {
     return deserializeSplice(operationMessage.getSplice())


### PR DESCRIPTION
adds docstrings for the public-facing `Document` API.
i wasn't positive how to handle types (like `Checkpoint`, `Transaction`, and `Point`), so i left them as "`Transaction {Object}`" or similar